### PR TITLE
Fixing token not expiring in correct conditions

### DIFF
--- a/Tests/AsyncTests/TokenTestsAsync.cs
+++ b/Tests/AsyncTests/TokenTestsAsync.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Trustev.Domain;
+using Trustev.Domain.Entities;
+using Trustev.Domain.Exceptions;
+using Trustev.WebAsync;
+
+namespace Tests.AsyncTests
+{
+    [TestClass]
+    public class TokenTestsAsync : TestBase
+    {
+        [TestMethod]
+        public async Task TestRenewApiToken()
+        {
+            var currentApiToken = await ApiClient.GetTokenAsync();
+            ApiClient.ExpireAt = DateTime.UtcNow.AddMinutes(-1);
+            var newApiToken = await ApiClient.GetTokenAsync();
+
+            Assert.AreNotEqual(currentApiToken, newApiToken);
+        }
+
+        [TestMethod]
+        public async Task TestKeepSameApiToken()
+        {
+            var currentApiToken = await ApiClient.GetTokenAsync();
+            var newApiToken = await ApiClient.GetTokenAsync();
+
+            Assert.AreEqual(currentApiToken, newApiToken);
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="AsyncTests\PaymentTestsAsync.cs" />
     <Compile Include="AsyncTests\SessionTestsAsync.cs" />
     <Compile Include="AsyncTests\TestBase.cs" />
+    <Compile Include="AsyncTests\TokenTestsAsync.cs" />
     <Compile Include="AsyncTests\TransactionAddressTestsAsync.cs" />
     <Compile Include="AsyncTests\TransactionItemTestsAsync.cs" />
     <Compile Include="AsyncTests\TransactionTestsAsync.cs" />

--- a/Trustev.Nuget/Package.nuspec
+++ b/Trustev.Nuget/Package.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Trustev</id>
-        <version>1.0.28</version>
+        <version>1.0.29</version>
         <title>Trustev Api Client</title>
         <authors>Trustev</authors>
         <owners>Trustev</owners>
@@ -11,7 +11,7 @@
         <iconUrl>https://app.trustev.com/assets/img/apple-icon-144.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>This is the Trustev Client which provides a set of classes and methods which can be used to integrate to the Trustev Platform.</description>
-        <releaseNotes>Updated API client to reuse API tokens by default.</releaseNotes>
+        <releaseNotes>Fixed Token reuse method to respect token expiry conditions</releaseNotes>
         <copyright>Copyright 2018</copyright>
         <tags>Trustev trustev api client</tags>
         <dependencies>

--- a/Trustev.WebAsync/ApiClient.cs
+++ b/Trustev.WebAsync/ApiClient.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
@@ -43,7 +41,7 @@ namespace Trustev.WebAsync
         /// <summary>
         ///API auth token
         /// </summary>
-        private static string ApiToken
+        public static string ApiToken
         {
             get
             {
@@ -57,13 +55,21 @@ namespace Trustev.WebAsync
         /// <summary>
         /// Token Expiry DateTime
         /// </summary>
-        private static DateTime? ExpireAt
+        public static DateTime? ExpireAt
         {
             get
             {
                 lock (TokenLock)
                 {
                     return _token?.ExpireAt;
+                }
+            }
+
+            set
+            {
+                lock (TokenLock)
+                {
+                    _token.ExpireAt = (DateTime)value;
                 }
             }
         }
@@ -855,7 +861,7 @@ namespace Trustev.WebAsync
             return JsonConvert.DeserializeObject<T>(resultstring, jss);
         }
 
-        #region Private Methods
+        
         /// <summary>
         /// Gets value of APIToken.
         /// Determins whether or not to generate a token on each request or reuse the current one if
@@ -863,11 +869,11 @@ namespace Trustev.WebAsync
         /// </summary>
         /// <param name="regenerateToken"></param>
         /// <returns></returns>
-        private static async Task<string> GetTokenAsync()
+        public static async Task<string> GetTokenAsync()
         {
             if (!RegenerateTokenOnEachRequest)
             {
-                if (string.IsNullOrEmpty(ApiToken) || ExpireAt  == null || ExpireAt.Value >= DateTime.UtcNow)
+                if (string.IsNullOrEmpty(ApiToken) || ExpireAt  == null || ExpireAt.Value <= DateTime.UtcNow)
                 {
                     await SetTokenAsync();
                 }
@@ -883,9 +889,8 @@ namespace Trustev.WebAsync
         /// Sets new APIToken and ExpiryDate on each call
         /// </summary>
         /// <returns></returns>
-        private static async Task SetTokenAsync()
+        public static async Task SetTokenAsync()
         {
-            
             CheckCredentials();
 
             DateTime currentTime = DateTime.UtcNow;
@@ -907,6 +912,7 @@ namespace Trustev.WebAsync
             CachedToken = response;
         }
 
+        #region Private Methods
         /// <summary>
         /// Check that the user has set the TrustevClient Credentials correctly
         /// </summary>


### PR DESCRIPTION
Making some methods/properties public as to allow for unit tests around the token renewal.
These methods are:
 - GetTokenAsync()
 - SetTokenAsync()
 - ApiToken
 - ExpireAt